### PR TITLE
Update README to reflect renaming meta to working group

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Following the [definitions described in opensource.guide](https://opensource.gui
 
 Technical Decisions can be interpreted as contributions being made to projects in the AssemblyScript Github Organization.
 
-For this, we will be following BDFL. Daniel Wirtz (@dcodeIO) is the designated project lead. Thus, in the case there is conflict between contributors, the lead will be the one to make the final decision.
+For this, we will be following BDFL. Daniel Wirtz ([@dcodeIO](https://github.com/dcodeIO)) is the designated project lead. Thus, in the case there is conflict between contributors, the lead will be the one to make the final decision.
 
 ## Organizational Decisions
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ The Working Group repository contains discussions, goals, roadmaps, assets, and 
 * [Governance](#governance)
   * [Technical Decisions](#technical-decisions)
   * [Organizational Decisions](#organizational-decisions)
-  * [Teams](#teams)
-    * [Compiler](#compiler)
-    * [Advocate](#advocate)
-    * [Developer Experience](#developer-experience)
+* [Groups](#groups)
+  * [Working Group](#working-group)
+  * [Community Group](#community-group)
+* [Teams](#teams)
+  * [Compiler](#compiler)
+  * [Advocate](#advocate)
+  * [Developer Experience](#developer-experience)
+* [Getting Involved](#getting-involved)
 
 # Goals
 
@@ -45,7 +49,21 @@ Organizational Descisions can be interpreted as contributions to the general pro
 
 For this, we will be following a meritocracy. Where consensus will be requested on issues opened on this repo to get a community vote, and can find a path going forward.
 
-## Teams
+# Groups
+
+The AssemblyScript project has meetings and and correspondance divided into groups. These groups communicate and work together very closely, and provides a way for focused discussions for those who need that.
+
+## Working Group
+
+The working group is for those who would like to contribute to the project directly. Whether that be through getting advice on technical implementations, showing off a new tool they are building, or just generally talking about the AssemblyScript project and where it is headed.
+
+**Anyone working on anything related to the AssemblyScript project is welcome to participate in the Working Group!**
+
+## Community Group
+
+The [community group](https://github.com/AssemblyScript/community-group) is for those who would like to discuss with other community members (including members of the working group) using AssemblyScript in their applications. The goal being that they can prioritize their core feature requests and use cases and communicate that to the working group. Which can help reduce duplicating efforts amongst the community, and allow the community to be collectively more productive!
+
+# Teams
 
 The AssemblyScript Working Group is divided into teams. The teams make design, architectural, and organizational decisions for their relevant domains and repositories by consensus. If consensus can't be made, then the project lead may act as a tie-breaker.
 
@@ -56,7 +74,7 @@ The AssemblyScript Working Group is divided into teams. The teams make design, a
 * All members of a team must adhere to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 * Membership does not imply commit access to a repository. Commit access should be handled by the maintainer of the repository, or by consensus of the respective team.
 
-### Compiler
+## Compiler
 
 The Compiler team works directly on the AssemblyScript compiler and its standard library, mostly under the [AssemblyScript/assemblyscript](https://github.com/AssemblyScript/assemblyscript) repository.
 
@@ -67,7 +85,7 @@ The Compiler team works directly on the AssemblyScript compiler and its standard
 * **Duncan Uszkay** (@DuncanUszkay1) - Regular Contributor [Shopify](https://www.shopify.com/)
 * **Aaron Turner** (@torch2424) - Regular Contributor, [Fastly](https://www.fastly.com/)
 
-### Advocate
+## Advocate
 
 The Advocate team works on projects, demos, talks, giving feedback on "messaging" about the project, and writing articles to help grow popularity and improve outreach.
 
@@ -75,7 +93,7 @@ The Advocate team works on projects, demos, talks, giving feedback on "messaging
 * **Joshua Tenner** (@jtenner) - [Speaker](https://dev.to/jtenner/an-assemblyscript-primer-for-typescript-developers-lf1)
 * **Willem Wyndham** (@willemneal) - [Teacher](http://www.cs.umd.edu/class/spring2019/cmsc388I/assemblyscript.html)
 
-### Developer Experience
+## Developer Experience
 
 The Developer Experience team works on projects such as tools, or anything that helps people be productive with AssemblyScript.
 
@@ -83,3 +101,14 @@ The Developer Experience team works on projects such as tools, or anything that 
 * **Joshua Tenner** (@jtenner) - Author of [as-pect](https://github.com/jtenner/as-pect) and [as2d](https://github.com/as2d/as2d)
 * **Willem Wyndham** (@willemneal) - Developer Experience at [NEAR](https://nearprotocol.com)
 * **Bowen Wang** (@bowenwang1996) - Developer Experience at [NEAR](https://nearprotocol.com)
+
+# Getting Involved
+
+We're happy to help you get involved! Currently, there are a few things you could do to start getting involved with the working group:
+
+* Reach out to a team member, and get invited to the AssemblyScript slack.
+
+* Join one of our [upcoming public meetings](https://github.com/AssemblyScript/working-group/issues?q=is%3Aissue+is%3Aopen+public+meeting).
+
+* Open an issue on the [working-group issues](https://github.com/AssemblyScript/working-group/issues), or any of the [AssemblyScript repositories](https://github.com/AssemblyScript).
+

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The working group is for those who would like to contribute to the project direc
 
 ## Community Group
 
-The [community group](https://github.com/AssemblyScript/community-group) is for those who would like to discuss with other community members (including members of the working group) using AssemblyScript in their applications. The goal being that they can prioritize their core feature requests and use cases and communicate that to the working group. Which can help reduce duplicating efforts amongst the community, and allow the community to be collectively more productive!
+The [community group](https://github.com/AssemblyScript/community-group) is for those who would like to discuss with other community members (including members of the working group) using AssemblyScript in their applications. Its goal is to communicate core feature requests and use cases to aid in prioritizing the working group's efforts.  Which can help reduce duplicating efforts amongst the community, and allow the community to be collectively more productive!
 
 # Teams
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![AssemblyScript Logo](https://avatars1.githubusercontent.com/u/28916798?s=64) AssemblyScript Working Group
 =================
 
-The Working Group repository contains discussions, goals, roadmaps, assets, and other aspects directly related to AssemblyScript development or project organization.
+The Working Group repository contains discussions, goals, roadmaps, assets, etc. directly related to AssemblyScript development or project organization.
 
 **Related**
 
@@ -25,7 +25,7 @@ The Working Group repository contains discussions, goals, roadmaps, assets, and 
 
 # Goals
 
-The goals of the AssemblyScript Working Group are:
+The goals of the Working Group are:
 
 * Target feature parity with WebAssembly and related technology.
 * Support non-browser use cases well (i.e. serverless, blockchain, etc...).
@@ -45,44 +45,42 @@ For this, we will be following BDFL. Daniel Wirtz (@dcodeIO) is the designated p
 
 ## Organizational Decisions
 
-Organizational Descisions can be interpreted as contributions to the general project direction, goals, roadmap, maintainers, etc...
+Organizational decisions can be interpreted as contributions to the general project direction, goals, roadmap, maintainers, etc...
 
 For this, we will be following a meritocracy. Where consensus will be requested on issues opened on this repo to get a community vote, and can find a path going forward.
 
 # Groups
 
-The AssemblyScript project has meetings and and correspondance divided into groups. These groups communicate and work together very closely, and provides a way for focused discussions for those who need that.
+The AssemblyScript Project has meetings and correspondance divided into groups. These groups communicate and work together very closely, and the meetings provide interested parties a way for focused discussions.
 
 ## Working Group
 
-The working group is for those who would like to contribute to the project directly. Whether that be through getting advice on technical implementations, showing off a new tool they are building, or just generally talking about the AssemblyScript project and where it is headed.
-
-**Anyone working on anything related to the AssemblyScript project is welcome to participate in the Working Group!**
+The Working Group is for those who would like to contribute to the project directly. Whether that be through getting advice on technical implementations, proposing a specific change or addition, or just generally talking about the AssemblyScript project and where it is headed.
 
 ## Community Group
 
-The [community group](https://github.com/AssemblyScript/community-group) is for those who would like to discuss with other community members (including members of the working group) using AssemblyScript in their applications. Its goal is to communicate core feature requests and use cases to aid in prioritizing the working group's efforts.  Which can help reduce duplicating efforts amongst the community, and allow the community to be collectively more productive!
+The [Community Group](https://github.com/AssemblyScript/community-group) is for those who would like to discuss with other community members (including members of the Working Group) using AssemblyScript in their applications. Its goal is to communicate core feature requests and use cases to aid in prioritizing the working group's efforts, which can help reduce duplicating efforts amongst the community, and allow the community to be collectively more productive!
 
 # Teams
 
-The AssemblyScript Working Group is divided into teams. The teams make design, architectural, and organizational decisions for their relevant domains and repositories by consensus. If consensus can't be made, then the project lead may act as a tie-breaker.
+The Working Group is divided into teams. The teams make design, architectural, and organizational decisions for their relevant domains and repositories by consensus. If consensus can't be made, then the project lead may act as a tie-breaker.
 
 **Membership guidelines**:
 
-* Anyone who is making significant contributions to the project (whether it be code, documentation, outreach, etc...) in the domains associated with the Working Group is welcome to join and request to join a team! :)
+* Anyone who is making significant contributions to the project (whether it be code, documentation, outreach, etc...) in the domains associated with the Working Group is welcome to request to join a team!
 * Membership does not require any required responsibilities outside of general activity in the respective domain. The project is open source and contributions are made at one's own accord. So help when you can. If things get busy on a member's end, that is okay! We welcome back all awesome contributors after a haitus.
 * All members of a team must adhere to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 * Membership does not imply commit access to a repository. Commit access should be handled by the maintainer of the repository, or by consensus of the respective team.
 
 ## Compiler
 
-The Compiler team works directly on the AssemblyScript compiler and its standard library, mostly under the [AssemblyScript/assemblyscript](https://github.com/AssemblyScript/assemblyscript) repository.
+The Compiler team works directly on the AssemblyScript compiler, its standard library or provided tools, mostly under the [AssemblyScript/assemblyscript](https://github.com/AssemblyScript/assemblyscript) repository.
 
 * **Daniel Wirtz** (@dcodeIO) - Author of AssemblyScript
 * **Max Graey** (@MaxGraey) - Author of large parts of the Standard Library
 * **Joshua Tenner** (@jtenner) - Regular Contributor
 * **Bowen Wang** (@bowenwang1996) - Regular Contributor, [NEAR](https://nearprotocol.com/)
-* **Duncan Uszkay** (@DuncanUszkay1) - Regular Contributor [Shopify](https://www.shopify.com/)
+* **Duncan Uszkay** (@DuncanUszkay1) - Regular Contributor, [Shopify](https://www.shopify.com/)
 * **Aaron Turner** (@torch2424) - Regular Contributor, [Fastly](https://www.fastly.com/)
 
 ## Advocate
@@ -97,18 +95,15 @@ The Advocate team works on projects, demos, talks, giving feedback on "messaging
 
 The Developer Experience team works on projects such as tools, or anything that helps people be productive with AssemblyScript.
 
-* **Aaron Turner** (@torch2424) - Author [Wasm By Example](https://github.com/torch2424/wasm-by-example) and [as-bind](https://github.com/torch2424/as-bind)
+* **Aaron Turner** (@torch2424) - Author of [Wasm By Example](https://github.com/torch2424/wasm-by-example) and [as-bind](https://github.com/torch2424/as-bind)
 * **Joshua Tenner** (@jtenner) - Author of [as-pect](https://github.com/jtenner/as-pect) and [as2d](https://github.com/as2d/as2d)
 * **Willem Wyndham** (@willemneal) - Developer Experience at [NEAR](https://nearprotocol.com)
 * **Bowen Wang** (@bowenwang1996) - Developer Experience at [NEAR](https://nearprotocol.com)
 
 # Getting Involved
 
-We're happy to help you get involved! Currently, there are a few things you could do to start getting involved with the working group:
+We're happy to help you get involved! Currently, there are a few things you could do to start getting involved with the Working Group:
 
-* Reach out to a team member, and get invited to the AssemblyScript slack.
-
+* Reach out to a team member, and get invited to the AssemblyScript Slack.
 * Join one of our [upcoming public meetings](https://github.com/AssemblyScript/working-group/issues?q=is%3Aissue+is%3Aopen+public+meeting).
-
-* Open an issue on the [working-group issues](https://github.com/AssemblyScript/working-group/issues), or any of the [AssemblyScript repositories](https://github.com/AssemblyScript).
-
+* Open an issue on the [working-group repository](https://github.com/AssemblyScript/working-group/issues), or any of the [AssemblyScript repositories](https://github.com/AssemblyScript).

--- a/README.md
+++ b/README.md
@@ -76,29 +76,29 @@ The Working Group is divided into teams. The teams make design, architectural, a
 
 The Compiler team works directly on the AssemblyScript compiler, its standard library or provided tools, mostly under the [AssemblyScript/assemblyscript](https://github.com/AssemblyScript/assemblyscript) repository.
 
-* **Daniel Wirtz** (@dcodeIO) - Author of AssemblyScript
-* **Max Graey** (@MaxGraey) - Author of large parts of the Standard Library
-* **Joshua Tenner** (@jtenner) - Regular Contributor
-* **Bowen Wang** (@bowenwang1996) - Regular Contributor, [NEAR](https://nearprotocol.com/)
-* **Duncan Uszkay** (@DuncanUszkay1) - Regular Contributor, [Shopify](https://www.shopify.com/)
-* **Aaron Turner** (@torch2424) - Regular Contributor, [Fastly](https://www.fastly.com/)
+* **Daniel Wirtz** ([@dcodeIO](https://github.com/dcodeIO)) - Author of AssemblyScript
+* **Max Graey** ([@MaxGraey](https://github.com/MaxGraey)) - Author of large parts of the Standard Library
+* **Joshua Tenner** ([@jtenner](https://github.com/jtenner)) - Regular Contributor
+* **Bowen Wang** ([@bowenwang1996](https://github.com/bowenwang1996)) - Regular Contributor, [NEAR](https://nearprotocol.com/)
+* **Duncan Uszkay** ([@DuncanUszkay1](https://github.com/DuncanUszkay1)) - Regular Contributor, [Shopify](https://www.shopify.com/)
+* **Aaron Turner** ([@torch2424](https://github.com/torch2424)) - Regular Contributor, [Fastly](https://www.fastly.com/)
 
 ## Advocate
 
 The Advocate team works on projects, demos, talks, giving feedback on "messaging" about the project, and writing articles to help grow popularity and improve outreach.
 
-* **Aaron Turner** (@torch2424) - [Speaker](https://youtu.be/ZlL1nduatZQ)
-* **Joshua Tenner** (@jtenner) - [Speaker](https://dev.to/jtenner/an-assemblyscript-primer-for-typescript-developers-lf1)
-* **Willem Wyndham** (@willemneal) - [Teacher](http://www.cs.umd.edu/class/spring2019/cmsc388I/assemblyscript.html)
+* **Aaron Turner** ([@torch2424](https://github.com/torch2424)) - [Speaker](https://youtu.be/ZlL1nduatZQ)
+* **Joshua Tenner** ([@jtenner](https://github.com/jtenner)) - [Speaker](https://dev.to/jtenner/an-assemblyscript-primer-for-typescript-developers-lf1)
+* **Willem Wyndham** ([@willemneal](https://github.com/willemneal)) - [Teacher](http://www.cs.umd.edu/class/spring2019/cmsc388I/assemblyscript.html)
 
 ## Developer Experience
 
 The Developer Experience team works on projects such as tools, or anything that helps people be productive with AssemblyScript.
 
-* **Aaron Turner** (@torch2424) - Author of [Wasm By Example](https://github.com/torch2424/wasm-by-example) and [as-bind](https://github.com/torch2424/as-bind)
-* **Joshua Tenner** (@jtenner) - Author of [as-pect](https://github.com/jtenner/as-pect) and [as2d](https://github.com/as2d/as2d)
-* **Willem Wyndham** (@willemneal) - Developer Experience at [NEAR](https://nearprotocol.com)
-* **Bowen Wang** (@bowenwang1996) - Developer Experience at [NEAR](https://nearprotocol.com)
+* **Aaron Turner** ([@torch2424](https://github.com/torch2424)) - Author of [Wasm By Example](https://github.com/torch2424/wasm-by-example) and [as-bind](https://github.com/torch2424/as-bind)
+* **Joshua Tenner** ([@jtenner](https://github.com/jtenner)) - Author of [as-pect](https://github.com/jtenner/as-pect) and [as2d](https://github.com/as2d/as2d)
+* **Willem Wyndham** ([@willemneal](https://github.com/willemneal)) - Developer Experience at [NEAR](https://nearprotocol.com)
+* **Bowen Wang** ([@bowenwang1996](https://github.com/bowenwang1996)) - Developer Experience at [NEAR](https://nearprotocol.com)
 
 # Getting Involved
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-![AssemblyScript Logo](https://avatars1.githubusercontent.com/u/28916798?s=64) AssemblyScript "meta"
+![AssemblyScript Logo](https://avatars1.githubusercontent.com/u/28916798?s=64) AssemblyScript Working Group
 =================
 
-A repo for discussions, goals, roadmaps, assets, and other things related to the AssemblyScript project.
+The Working Group repository contains discussions, goals, roadmaps, assets, and other aspects directly related to AssemblyScript development or project organization.
 
-If this is not what you were looking for, please see the [main AssemblyScript repo here](https://github.com/AssemblyScript/assemblyscript). Where you can also find how to sponsor the project.
+**Related**
 
-# Table of Contents
+* [AssemblyScript Compiler](https://github.com/AssemblyScript/assemblyscript)
+* [AssemblyScript Community Group](https://github.com/AssemblyScript/community-group)
+
+**Contents**
 
 * [Goals](#goals)
 * [Governance](#governance)
@@ -13,42 +16,28 @@ If this is not what you were looking for, please see the [main AssemblyScript re
   * [Organizational Decisions](#organizational-decisions)
   * [Teams](#teams)
     * [Compiler](#compiler)
-      * [Daniel Wirtz](#daniel-wirtz)
-      * [Max Graey](#max-graey)
-      * [Bowen Wang](#bowen-wang)
-      * [Joshua Tenner](#joshua-tenner)
     * [Advocate](#advocate)
-      * [Aaron Turner](#aaron-turner)
-      * [Joshua Tenner](#joshua-tenner)
-      * [Willem Wyndham](#willem-wyndham)
     * [Developer Experience](#developer-experience)
-      * [Joshua Tenner](#joshua-tenner-1)
-      * [Willem Wyndham](#willem-wyndham-1)
-      * [Bowen Wang](#bowen-wang-1)
 
 # Goals
 
-The current goals of the AssemblyScript project are:
+The goals of the AssemblyScript Working Group are:
 
 * Target feature parity with WebAssembly and related technology.
-
 * Support non-browser use cases well (i.e. serverless, blockchain, etc...).
-
 * Stay backwards-compatible to TypeScript syntax and JavaScript APIs as much as possible and reasonable.
-
 * Complement current web projects, and support building WebAssembly modules "from scratch". By offering "fine-grain" control to developers.
-
 * Focus on developer experience, and try to be a great language for new and existing web developers. 
 
 # Governance
 
-Following the [definitions described in opensource.guide](https://opensource.guide/leadership-and-governance/#what-are-some-of-the-common-governance-structures-for-open-source-projects). The Governance for the project is split into two parts:
+Following the [definitions described in opensource.guide](https://opensource.guide/leadership-and-governance/#what-are-some-of-the-common-governance-structures-for-open-source-projects), governance is split into two parts:
 
 ## Technical Decisions
 
-Technical Decisions can be interpreted as contributions being made to projects in the AssemblyScript Github Org.
+Technical Decisions can be interpreted as contributions being made to projects in the AssemblyScript Github Organization.
 
-For this, we will be following BDFL. Daniel Wirtz (@dcodeIO) is the designated lead. Thus, in the case there is conflict between contributors, the lead will be the one to make the final decision.
+For this, we will be following BDFL. Daniel Wirtz (@dcodeIO) is the designated project lead. Thus, in the case there is conflict between contributors, the lead will be the one to make the final decision.
 
 ## Organizational Decisions
 
@@ -58,134 +47,38 @@ For this, we will be following a meritocracy. Where consensus will be requested 
 
 ## Teams
 
-The AssemblyScript project members is divided into teams. The teams make design, architectural, and new-membership decisions for their relevant domains and repositories by consensus. If consensus can't be made, then the Compiler team (specifically @dcodeIO) may act as a tie-breaker. 
+The AssemblyScript Working Group is divided into teams. The teams make design, architectural, and organizational decisions for their relevant domains and repositories by consensus. If consensus can't be made, then the project lead may act as a tie-breaker.
 
 **Membership guidelines**:
 
-* Anyone who is making significant contributions to the project (whether it be code, documentation, outreach, their own awesome project, etc...) is welcome to join the communitty and request to join a team! :)
-
-* Membership does not require any required responsibilities outside of general activity in the communitty. The project is open source and contributions are made at one's own accord. So help when you can. If things get busy on a member's end, that is okay! We welcome back all awesome contributors back after a haitus.
-
+* Anyone who is making significant contributions to the project (whether it be code, documentation, outreach, etc...) in the domains associated with the Working Group is welcome to join and request to join a team! :)
+* Membership does not require any required responsibilities outside of general activity in the respective domain. The project is open source and contributions are made at one's own accord. So help when you can. If things get busy on a member's end, that is okay! We welcome back all awesome contributors after a haitus.
 * All members of a team must adhere to the [Code of Conduct](./CODE_OF_CONDUCT.md).
-
-* Membership does not grant commit access to a repository. Commit access should be handled by the author of the repository, or by consensus of the respective team.
+* Membership does not imply commit access to a repository. Commit access should be handled by the maintainer of the repository, or by consensus of the respective team.
 
 ### Compiler
 
-The "Compiler" team works on the AssemblyScript compiler and its standard library. Mostly, under the [AssemblyScript/assemblyscript](https://github.com/AssemblyScript/assemblyscript) repository.
+The Compiler team works directly on the AssemblyScript compiler and its standard library, mostly under the [AssemblyScript/assemblyscript](https://github.com/AssemblyScript/assemblyscript) repository.
 
-#### Daniel Wirtz
-
-![Daniel Wirtz Avatar](https://avatars0.githubusercontent.com/u/1136893?s=150&v=4)
-
-[Github](https://github.com/dcodeIO) | [Website](https://dcode.io/)
-
-**Author/Creator of AssemblyScript.**
-
-#### Max Graey
-
-![Max Graey Avatar](https://avatars0.githubusercontent.com/u/1301959?s=150&v=4)
-
-[Github](https://github.com/MaxGraey) | [Twitter](https://twitter.com/MaxGraey)
-
-#### Bowen Wang
-
-[Github](https://github.com/bowenwang1996)
-
-Notable Projects:
-
-* Developer at [Near](https://nearprotocol.com/)
-
-* [Smart Contract Library for AssemblyScript](https://github.com/nearprotocol/near-runtime-ts)
-
-#### Joshua Tenner
-
-[Github](https://github.com/jtenner)
+* **Daniel Wirtz** (@dcodeIO) - Author of AssemblyScript<br />
+* **Max Graey** (@MaxGraey) - Author of large parts of the Standard Library<br />
+* **Joshua Tenner** (@jtenner) - Regular Contributor<br />
+* **Aaron Turner** (@torch2424) - Regular Contributor<br />
+* **Bowen Wang** (@bowenwang1996) - Regular Contributor<br />
 
 ### Advocate
 
-The "Advocate" team works on projects, demos, talks, giving feedback on "messaging" about the project, and writing articles to help grow popularity and improve outreach.
+The Advocate team works on projects, demos, talks, giving feedback on "messaging" about the project, and writing articles to help grow popularity and improve outreach.
 
-#### Aaron Turner
-
-![Aaron Turner Avatar](https://avatars0.githubusercontent.com/u/1448289?s=150&v=4)
-
-[Github](https://github.com/torch2424) | [Website](https://aaronthedev.com/)
-
-Notable Projects: 
-
-* [WasmBoy](https://github.com/torch2424/wasmboy)
-* [VaporBoy](https://github.com/torch2424/vaporBoy)
-* [Wasm Matrix](https://github.com/torch2424/wasm-matrix)
-* [Wasm By Example](https://github.com/torch2424/wasm-by-example) 
-
-Notable Talks:
-
-* [WebAssembly for JavaScript developers](https://youtu.be/ZlL1nduatZQ)
-
-Notable Articles:
-
-* [Benchmark of WebAssembly vs ES6](https://medium.com/@torch2424/webassembly-is-fast-a-real-world-benchmark-of-webassembly-vs-es6-d85a23f8e193)
-
-#### Joshua Tenner
-
-[Github](https://github.com/jtenner)
-
-Notable Projects:
-
-* [as-pect](https://github.com/jtenner/as-pect)
-* [as2d](https://github.com/as2d/as2d)
-
-Notable Articles:
-
-* [An AssemblyScript Primer for TypeScript Developers](https://dev.to/jtenner/an-assemblyscript-primer-for-typescript-developers-lf1)
-
-#### Willem Wyndham
-
-![Willem Wyndham Avatar](https://avatars0.githubusercontent.com/u/1483244?s=150&v=4)
-
-[Github](https://github.com/willemneal)
-
-Notable Projects:
-
-* [AssemblyScript University Course](http://www.cs.umd.edu/class/spring2019/cmsc388I/assemblyscript.html)
-* Contributor to [as-pect](https://github.com/jtenner/as-pect)
+* **Aaron Turner** (@torch2424) - [Speaker](https://youtu.be/ZlL1nduatZQ)
+* **Joshua Tenner** (@jtenner) - [Speaker](https://dev.to/jtenner/an-assemblyscript-primer-for-typescript-developers-lf1)
+* **Willem Wyndham** (@willemneal) - [Teacher](http://www.cs.umd.edu/class/spring2019/cmsc388I/assemblyscript.html)
 
 ### Developer Experience
 
-The "Developer Experience" team works on projects such as tools, or anything that helps people be productive with AssemblyScript.
+The Developer Experience team works on projects such as tools, or anything that helps people be productive with AssemblyScript.
 
-
-#### Joshua Tenner
-
-[Github](https://github.com/jtenner)
-
-Notable Projects:
-
-* [as-pect](https://github.com/jtenner/as-pect)
-* [as2d](https://github.com/as2d/as2d)
-
-Notable Articles:
-
-* [An AssemblyScript Primer for TypeScript Developers](https://dev.to/jtenner/an-assemblyscript-primer-for-typescript-developers-lf1)
-
-#### Willem Wyndham
-
-![Willem Wyndham Avatar](https://avatars0.githubusercontent.com/u/1483244?s=150&v=4)
-
-[Github](https://github.com/willemneal)
-
-Notable Projects:
-
-* [AssemblyScript University Course](http://www.cs.umd.edu/class/spring2019/cmsc388I/assemblyscript.html)
-* Contributor to [as-pect](https://github.com/jtenner/as-pect)
-
-#### Bowen Wang
-
-[Github](https://github.com/bowenwang1996)
-
-Notable Projects:
-
-* Developer at [Near](https://nearprotocol.com/)
-
-* [Smart Contract Library for AssemblyScript](https://github.com/nearprotocol/near-runtime-ts)
+* **Aaron Turner** (@torch2424) - Author [Wasm By Example](https://github.com/torch2424/wasm-by-example) and [as-bind](https://github.com/torch2424/as-bind)
+* **Joshua Tenner** (@jtenner) - Author of [as-pect](https://github.com/jtenner/as-pect) and [as2d](https://github.com/as2d/as2d)
+* **Willem Wyndham** (@willemneal) - Developer Experience at [NEAR](https://nearprotocol.com)
+* **Bowen Wang** (@bowenwang1996) - Developer Experience at [NEAR](https://nearprotocol.com)


### PR DESCRIPTION
An attempt to concretize and slim down the README a bit, according to the latest rename and split into a WG and CG.

cc @torch2424 